### PR TITLE
Refactor pigeon package

### DIFF
--- a/packages/flutter_whisperkit/pigeons/ios_whisper_kit_api.dart
+++ b/packages/flutter_whisperkit/pigeons/ios_whisper_kit_api.dart
@@ -2,9 +2,9 @@ import 'package:pigeon/pigeon.dart';
 
 @ConfigurePigeon(
   PigeonOptions(
-    dartOut: '../flutter_whisperkit/lib/src/whisper_kit_message.g.dart',
+    dartOut: 'lib/src/whisper_kit_message.g.dart',
     swiftOut:
-        'ios/flutter_whisperkit_apple/Sources/flutter_whisperkit_apple/WhisperKitMessage.g.swift',
+        '../flutter_whisperkit_apple/ios/flutter_whisperkit_apple/Sources/flutter_whisperkit_apple/WhisperKitMessage.g.swift',
     dartPackageName: 'flutter_whisperkit',
   ),
 )

--- a/packages/flutter_whisperkit/pigeons/macos_whisper_kit_api.dart
+++ b/packages/flutter_whisperkit/pigeons/macos_whisper_kit_api.dart
@@ -2,9 +2,9 @@ import 'package:pigeon/pigeon.dart';
 
 @ConfigurePigeon(
   PigeonOptions(
-    dartOut: '../flutter_whisperkit/lib/src/whisper_kit_message.g.dart',
+    dartOut: 'lib/src/whisper_kit_message.g.dart',
     swiftOut:
-        'macos/flutter_whisperkit_apple/Sources/flutter_whisperkit_apple/WhisperKitMessage.g.swift',
+        '../flutter_whisperkit_apple/macos/flutter_whisperkit_apple/Sources/flutter_whisperkit_apple/WhisperKitMessage.g.swift',
     dartPackageName: 'flutter_whisperkit',
   ),
 )

--- a/packages/flutter_whisperkit/pubspec.yaml
+++ b/packages/flutter_whisperkit/pubspec.yaml
@@ -13,6 +13,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
+  pigeon: ^25.3.1
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:

--- a/packages/flutter_whisperkit_apple/example/lib/main.dart
+++ b/packages/flutter_whisperkit_apple/example/lib/main.dart
@@ -141,6 +141,7 @@ class _MyAppState extends State<MyApp> {
             _loadingProgress = progress;
           });
         },
+        storageLocation: _storageLocation,
       );
 
       if (!mounted) return;

--- a/packages/flutter_whisperkit_apple/pubspec.yaml
+++ b/packages/flutter_whisperkit_apple/pubspec.yaml
@@ -13,7 +13,6 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.2
   flutter_whisperkit:
     path: ../flutter_whisperkit
 

--- a/packages/flutter_whisperkit_apple/pubspec.yaml
+++ b/packages/flutter_whisperkit_apple/pubspec.yaml
@@ -13,7 +13,6 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  pigeon: ^25.3.1
   plugin_platform_interface: ^2.0.2
   flutter_whisperkit:
     path: ../flutter_whisperkit


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->

## Related Issue
<!-- Please specify the Issue that this PR will close -->
Close #xxx

## Description
<!-- このPRで行った変更内容を詳細に記載してください -->

This pull request refactors the `flutter_whisperkit` and `flutter_whisperkit_apple` packages by reorganizing file paths, updating dependencies, and adding a new parameter to the example app. Key changes include updates to Pigeon configuration paths, dependency adjustments in `pubspec.yaml` files, and the addition of a `storageLocation` parameter in the example app.

### Refactoring and File Path Updates:
* Renamed `ios_whisper_kit_api.dart` and `macos_whisper_kit_api.dart` files to new locations under `flutter_whisperkit`, and updated the `dartOut` and `swiftOut` paths in their Pigeon configuration to reflect the new structure. (`[[1]](diffhunk://#diff-e5df265d8897e63834d86c3dc071ce91efeb5e118394a81abd4cadce1bf0aacfL5-R7)`, `[[2]](diffhunk://#diff-c45bb6762d7b140dc86acbc3877c3c422c88397846ed1f2231210b27962ed572L5-R7)`)

### Dependency Updates:
* Added the `pigeon` dependency (version `^25.3.1`) to `flutter_whisperkit/pubspec.yaml`. (`[packages/flutter_whisperkit/pubspec.yamlR16](diffhunk://#diff-8382dbd0fb1e63a0c4d3552a57179f8d2dd67b1755d5db97eca1461ed03a8686R16)`)
* Removed the `pigeon` and `plugin_platform_interface` dependencies from `flutter_whisperkit_apple/pubspec.yaml` to streamline dependency management. (`[packages/flutter_whisperkit_apple/pubspec.yamlL16-L17](diffhunk://#diff-cb1dc3205b5781b317493e89f9465246fe56ab5068a1f8f0aac4ed65fc8168eaL16-L17)`)

### Example App Enhancement:
* Added a `storageLocation` parameter to the `_MyAppState` class in the `flutter_whisperkit_apple` example app to support additional configuration. (`[packages/flutter_whisperkit_apple/example/lib/main.dartR144](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406R144)`)

## Checklist

- [ ]  xxx