### PR TITLE
modelDownloadPath を追加

### DIFF
--- a/packages/flutter_whisperkit/lib/flutter_whisperkit.dart
+++ b/packages/flutter_whisperkit/lib/flutter_whisperkit.dart
@@ -14,18 +14,18 @@ class FlutterWhisperkit {
   /// [variant] - The model variant to load (e.g., 'tiny-en', 'base', 'small', 'medium', 'large-v2').
   /// [modelRepo] - The repository to download the model from (default: 'argmaxinc/whisperkit-coreml').
   /// [redownload] - Whether to force redownload the model even if it exists locally.
-  /// [storageLocation] - Where to store the model (ModelStorageLocation.packageDirectory or ModelStorageLocation.userFolder).
+  /// [modelDownloadPath] - The path to download the model to.
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
     bool? redownload,
-    ModelStorageLocation storageLocation = ModelStorageLocation.packageDirectory,
+    String? modelDownloadPath,
   }) {
     return FlutterWhisperkitPlatform.instance.loadModel(
       variant,
       modelRepo: modelRepo,
       redownload: redownload,
-      storageLocation: storageLocation,
+      modelDownloadPath: modelDownloadPath,
     );
   }
 
@@ -100,9 +100,7 @@ class FlutterWhisperkit {
   /// Returns a success message when recording is stopped.
   /// If [loop] is false, also triggers transcription of the recorded audio.
   Future<String?> stopRecording({bool loop = true}) {
-    return FlutterWhisperkitPlatform.instance.stopRecording(
-      loop: loop,
-    );
+    return FlutterWhisperkitPlatform.instance.stopRecording(loop: loop);
   }
 
   /// Stream of real-time transcription results.
@@ -125,7 +123,7 @@ class FlutterWhisperkit {
   /// ```
   Stream<TranscriptionResult> get transcriptionStream =>
       FlutterWhisperkitPlatform.instance.transcriptionStream;
-      
+
   /// Stream of model loading progress updates.
   ///
   /// This stream emits Progress objects containing information about the ongoing task,

--- a/packages/flutter_whisperkit/lib/flutter_whisperkit_method_channel.dart
+++ b/packages/flutter_whisperkit/lib/flutter_whisperkit_method_channel.dart
@@ -90,13 +90,13 @@ class MethodChannelFlutterWhisperkit extends FlutterWhisperkitPlatform {
     String? variant, {
     String? modelRepo,
     bool? redownload,
-    ModelStorageLocation? storageLocation,
+    String? modelDownloadPath,
   }) async {
     return _whisperKitMessage.loadModel(
       variant,
       modelRepo,
       redownload,
-      storageLocation?.index,
+      modelDownloadPath,
     );
   }
 

--- a/packages/flutter_whisperkit/lib/flutter_whisperkit_platform_interface.dart
+++ b/packages/flutter_whisperkit/lib/flutter_whisperkit_platform_interface.dart
@@ -31,12 +31,12 @@ abstract class FlutterWhisperkitPlatform extends PlatformInterface {
   /// [variant] - The model variant to load (e.g., 'tiny-en', 'base', 'small', 'medium', 'large-v2').
   /// [modelRepo] - The repository to download the model from (default: 'argmaxinc/whisperkit-coreml').
   /// [redownload] - Whether to force redownload the model even if it exists locally.
-  /// [storageLocation] - Where to store the model (ModelStorageLocation.packageDirectory or ModelStorageLocation.userFolder).
+  /// [modelDownloadPath] - The path to download the model to.
   Future<String?> loadModel(
     String? variant, {
     String? modelRepo,
     bool? redownload,
-    ModelStorageLocation? storageLocation,
+    String? modelDownloadPath,
   }) {
     throw UnimplementedError('loadModel() has not been implemented.');
   }
@@ -106,7 +106,7 @@ abstract class FlutterWhisperkitPlatform extends PlatformInterface {
   Stream<TranscriptionResult> get transcriptionStream {
     throw UnimplementedError('transcriptionStream has not been implemented.');
   }
-  
+
   /// Stream of model loading progress updates.
   Stream<Progress> get modelProgressStream {
     throw UnimplementedError('modelProgressStream has not been implemented.');

--- a/packages/flutter_whisperkit/lib/src/model_loader.dart
+++ b/packages/flutter_whisperkit/lib/src/model_loader.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import '../flutter_whisperkit.dart';
-import 'models.dart';
 
 /// A class for loading and managing WhisperKit models.
 class WhisperKitModelLoader {
@@ -9,7 +8,6 @@ class WhisperKitModelLoader {
   WhisperKitModelLoader() : _whisperkit = FlutterWhisperkit();
 
   final FlutterWhisperkit _whisperkit;
-  ModelStorageLocation _storageLocation = ModelStorageLocation.packageDirectory;
 
   /// Loads a WhisperKit model.
   ///
@@ -23,14 +21,14 @@ class WhisperKitModelLoader {
     String modelRepo = 'argmaxinc/whisperkit-coreml',
     bool redownload = false,
     Function(double progress)? onProgress,
-    ModelStorageLocation? storageLocation,
+    String? modelDownloadPath,
   }) async {
     // Initialize the model loading
     final result = _whisperkit.loadModel(
       variant,
       modelRepo: modelRepo,
       redownload: redownload,
-      storageLocation: storageLocation ?? _storageLocation,
+      modelDownloadPath: modelDownloadPath,
     );
 
     // Subscribe to the progress stream if a callback is provided
@@ -47,14 +45,4 @@ class WhisperKitModelLoader {
       progressSubscription?.cancel();
     }
   }
-
-  /// Sets the storage location for WhisperKit models.
-  ///
-  /// [location] - The storage location to use.
-  void setStorageLocation(ModelStorageLocation location) {
-    _storageLocation = location;
-  }
-
-  /// Gets the current storage location for WhisperKit models.
-  ModelStorageLocation get storageLocation => _storageLocation;
 }

--- a/packages/flutter_whisperkit/lib/src/models.dart
+++ b/packages/flutter_whisperkit/lib/src/models.dart
@@ -2,7 +2,6 @@ library flutter_whisperkit.models;
 
 // Export the model classes
 export 'models/decoding_options.dart';
-export 'models/model_storage_location.dart';
 export 'models/transcription_result.dart';
 export 'models/word_timing.dart';
 export 'models/progress.dart';

--- a/packages/flutter_whisperkit/lib/src/models/model_storage_location.dart
+++ b/packages/flutter_whisperkit/lib/src/models/model_storage_location.dart
@@ -1,8 +1,0 @@
-/// Storage location for WhisperKit models.
-enum ModelStorageLocation {
-  /// Store models in the application's package directory.
-  packageDirectory,
-
-  /// Store models in a user-accessible folder.
-  userFolder,
-}

--- a/packages/flutter_whisperkit/lib/src/whisper_kit_message.g.dart
+++ b/packages/flutter_whisperkit/lib/src/whisper_kit_message.g.dart
@@ -50,14 +50,14 @@ class WhisperKitMessage {
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<String?> loadModel(String? variant, String? modelRepo, bool? redownload, int? storageLocation) async {
+  Future<String?> loadModel(String? variant, String? modelRepo, bool? redownload, String? modelDownloadPath) async {
     final String pigeonVar_channelName = 'dev.flutter.pigeon.flutter_whisperkit.WhisperKitMessage.loadModel$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[variant, modelRepo, redownload, storageLocation]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[variant, modelRepo, redownload, modelDownloadPath]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/packages/flutter_whisperkit/pigeons/whisper_kit_api.dart
+++ b/packages/flutter_whisperkit/pigeons/whisper_kit_api.dart
@@ -15,7 +15,7 @@ abstract class WhisperKitMessage {
     String? variant,
     String? modelRepo,
     bool? redownload,
-    int? storageLocation,
+    String? modelDownloadPath,
   );
   @async
   String? transcribeFromFile(String filePath, Map<String, Object?> options);

--- a/packages/flutter_whisperkit_apple/darwin/flutter_whisperkit_apple/Sources/flutter_whisperkit_apple/WhisperKitMessage.g.swift
+++ b/packages/flutter_whisperkit_apple/darwin/flutter_whisperkit_apple/Sources/flutter_whisperkit_apple/WhisperKitMessage.g.swift
@@ -88,7 +88,7 @@ class WhisperKitMessagePigeonCodec: FlutterStandardMessageCodec, @unchecked Send
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol WhisperKitMessage {
-  func loadModel(variant: String?, modelRepo: String?, redownload: Bool?, storageLocation: Int64?, completion: @escaping (Result<String?, Error>) -> Void)
+  func loadModel(variant: String?, modelRepo: String?, redownload: Bool?, modelDownloadPath: String?, completion: @escaping (Result<String?, Error>) -> Void)
   func transcribeFromFile(filePath: String, options: [String: Any?], completion: @escaping (Result<String?, Error>) -> Void)
   func startRecording(options: [String: Any?], loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func stopRecording(loop: Bool, completion: @escaping (Result<String?, Error>) -> Void)
@@ -107,8 +107,8 @@ class WhisperKitMessageSetup {
         let variantArg: String? = nilOrValue(args[0])
         let modelRepoArg: String? = nilOrValue(args[1])
         let redownloadArg: Bool? = nilOrValue(args[2])
-        let storageLocationArg: Int64? = nilOrValue(args[3])
-        api.loadModel(variant: variantArg, modelRepo: modelRepoArg, redownload: redownloadArg, storageLocation: storageLocationArg) { result in
+        let modelDownloadPathArg: String? = nilOrValue(args[3])
+        api.loadModel(variant: variantArg, modelRepo: modelRepoArg, redownload: redownloadArg, modelDownloadPath: modelDownloadPathArg) { result in
           switch result {
           case .success(let res):
             reply(wrapResult(res))

--- a/packages/flutter_whisperkit_apple/example/lib/main.dart
+++ b/packages/flutter_whisperkit_apple/example/lib/main.dart
@@ -38,9 +38,6 @@ class _MyAppState extends State<MyApp> {
   // Selected model variant
   String _selectedVariant = 'tiny-en';
 
-  // Selected storage location
-  ModelStorageLocation _storageLocation = ModelStorageLocation.packageDirectory;
-
   @override
   void dispose() {
     // Cancel the transcription subscription when the widget is disposed
@@ -130,9 +127,6 @@ class _MyAppState extends State<MyApp> {
     });
 
     try {
-      // Set the storage location
-      _modelLoader.setStorageLocation(_storageLocation);
-
       // Load the model
       final result = await _modelLoader.loadModel(
         variant: _selectedVariant,
@@ -143,7 +137,6 @@ class _MyAppState extends State<MyApp> {
             _loadingProgress = progress;
           });
         },
-        storageLocation: _storageLocation,
       );
 
       if (!mounted) return;
@@ -154,6 +147,7 @@ class _MyAppState extends State<MyApp> {
         _modelStatus = 'Model loaded: $result';
       });
     } on PlatformException catch (e) {
+      print('Error loading model: ${e.message}');
       setState(() {
         _isLoading = false;
         _isModelLoaded = false;
@@ -211,39 +205,6 @@ class _MyAppState extends State<MyApp> {
                         child: Text(value),
                       );
                     }).toList(),
-              ),
-
-              const SizedBox(height: 10),
-
-              // Storage location selection
-              Row(
-                children: [
-                  const Text('Storage Location: '),
-                  Radio<ModelStorageLocation>(
-                    value: ModelStorageLocation.packageDirectory,
-                    groupValue: _storageLocation,
-                    onChanged: (ModelStorageLocation? value) {
-                      if (value != null) {
-                        setState(() {
-                          _storageLocation = value;
-                        });
-                      }
-                    },
-                  ),
-                  const Text('Package Directory'),
-                  Radio<ModelStorageLocation>(
-                    value: ModelStorageLocation.userFolder,
-                    groupValue: _storageLocation,
-                    onChanged: (ModelStorageLocation? value) {
-                      if (value != null) {
-                        setState(() {
-                          _storageLocation = value;
-                        });
-                      }
-                    },
-                  ),
-                  const Text('User Folder'),
-                ],
               ),
 
               const SizedBox(height: 10),

--- a/packages/flutter_whisperkit_apple/test/flutter_whisperkit_apple_test.dart
+++ b/packages/flutter_whisperkit_apple/test/flutter_whisperkit_apple_test.dart
@@ -12,7 +12,8 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('FlutterWhisperkitApple', () {
-    final FlutterWhisperkitPlatform initialPlatform = FlutterWhisperkitPlatform.instance;
+    final FlutterWhisperkitPlatform initialPlatform =
+        FlutterWhisperkitPlatform.instance;
 
     test('FlutterWhisperkitApple extends FlutterWhisperkitPlatform', () {
       expect(FlutterWhisperkitApple(), isA<FlutterWhisperkitPlatform>());
@@ -22,13 +23,13 @@ void main() {
       // Arrange
       final mockWhisperKitMessage = MockWhisperKitMessage();
       final methodChannel = MethodChannelFlutterWhisperkitApple(
-        whisperKitMessage: mockWhisperKitMessage
+        whisperKitMessage: mockWhisperKitMessage,
       );
       final flutterWhisperkitApplePlugin = FlutterWhisperkitApple(
-        methodChannel: methodChannel
+        methodChannel: methodChannel,
       );
       setUpMockPlatform();
-      
+
       // Act & Assert
       expect(
         await flutterWhisperkitApplePlugin.loadModel(
@@ -46,22 +47,7 @@ void main() {
         final modelLoader = WhisperKitModelLoader();
 
         // Act & Assert
-        expect(
-          await modelLoader.loadModel(variant: 'tiny-en'),
-          'Model loaded',
-        );
-      });
-
-      test('can change storage location', () async {
-        // Arrange
-        setUpMockPlatform();
-        final modelLoader = WhisperKitModelLoader();
-        
-        // Act
-        modelLoader.setStorageLocation(ModelStorageLocation.userFolder);
-        
-        // Assert
-        expect(modelLoader.storageLocation, ModelStorageLocation.userFolder);
+        expect(await modelLoader.loadModel(variant: 'tiny-en'), 'Model loaded');
       });
     });
   });


### PR DESCRIPTION
<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->

## Related Issue
<!-- Please specify the Issue that this PR will close -->
Close #xxx

## Description
This pull request refactors the handling of model storage in the `flutter_whisperkit` package by replacing the `ModelStorageLocation` enum with a more flexible `modelDownloadPath` parameter. This change simplifies the codebase and provides users with greater control over where models are stored. Additionally, the example app and platform-specific implementations have been updated to reflect this change.

### Refactoring of Model Storage Handling:

* Replaced the `ModelStorageLocation` enum with a `modelDownloadPath` parameter across the `loadModel` method in `FlutterWhisperkit`, `FlutterWhisperkitPlatform`, and related classes. This allows specifying a custom path for model downloads instead of predefined locations. (`[[1]](diffhunk://#diff-3bf6eebe8713c53b6b4f28abee2a99d8417d875f9d1a46aeefca00195f9791d3L17-R28)`, `[[2]](diffhunk://#diff-473a1406a2e7546608a31e00dd8194fc72a3cdcce75d7eadf98a8782ba790123L93-R99)`, `[[3]](diffhunk://#diff-c3e169fd868399f968b217951fc372dcf778c4bda1557e5c3703f240ac4ae2b0L34-R39)`, `[[4]](diffhunk://#diff-c6e4ee44050ade198f447d749024d56c90c855fc84c525375775542bf33baf8bL26-R31)`, `[[5]](diffhunk://#diff-434f452588bffaab8354092d6056e07bdd9bccd9f4cba4b77a7f1eb192bd509dL53-R60)`, `[[6]](diffhunk://#diff-2b9798c6a80f542311aae322c88a92f97d16c44384cc4fc8116c791aa6c08bd8L18-R18)`, `[[7]](diffhunk://#diff-881f7319dc21d65e9d7cd92582cc815caa4571d83c659f32821306509395b4eaL12-L16)`, `[[8]](diffhunk://#diff-3756bd8d1f0db5b728e64977070f4da054bbc763d23b69dbf0fd429a453ed199L91-R91)`, `[[9]](diffhunk://#diff-3756bd8d1f0db5b728e64977070f4da054bbc763d23b69dbf0fd429a453ed199L110-R111)`)

* Removed the `ModelStorageLocation` enum and its associated logic, including the `setStorageLocation` and `getStorageLocation` methods, as well as related imports and UI elements in the example app. (`[[1]](diffhunk://#diff-fdf19ad34bcb4252bfb00bcb2d07c46a773d44d70d278bac045fe157b2674ddbL1-L8)`, `[[2]](diffhunk://#diff-c6e4ee44050ade198f447d749024d56c90c855fc84c525375775542bf33baf8bL4-L12)`, `[[3]](diffhunk://#diff-c6e4ee44050ade198f447d749024d56c90c855fc84c525375775542bf33baf8bL50-L59)`, `[[4]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L41-L43)`, `[[5]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L133-L135)`, `[[6]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L146)`, `[[7]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L218-L250)`)

### Updates to Platform-Specific Implementations:

* Updated the iOS implementation in `FlutterWhisperkitApplePlugin.swift` to use the `modelDownloadPath` parameter, including changes to the `getModelFolderPath` and `getLocalModels` methods. This ensures compatibility with the new approach and allows saving models to user-specified paths. (`[[1]](diffhunk://#diff-881f7319dc21d65e9d7cd92582cc815caa4571d83c659f32821306509395b4eaL26-R27)`, `[[2]](diffhunk://#diff-881f7319dc21d65e9d7cd92582cc815caa4571d83c659f32821306509395b4eaL45-R41)`, `[[3]](diffhunk://#diff-881f7319dc21d65e9d7cd92582cc815caa4571d83c659f32821306509395b4eaL93-R81)`, `[[4]](diffhunk://#diff-881f7319dc21d65e9d7cd92582cc815caa4571d83c659f32821306509395b4eaR103-R127)`, `[[5]](diffhunk://#diff-881f7319dc21d65e9d7cd92582cc815caa4571d83c659f32821306509395b4eaL350-R379)`, `[[6]](diffhunk://#diff-881f7319dc21d65e9d7cd92582cc815caa4571d83c659f32821306509395b4eaL383-R391)`)

### Example App Enhancements:

* Removed UI elements and logic related to selecting a storage location in the example app, simplifying the user interface and aligning it with the new `modelDownloadPath` approach. (`[[1]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L41-L43)`, `[[2]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L133-L135)`, `[[3]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L146)`, `[[4]](diffhunk://#diff-e949ab85fb25d9d7f952fee3050ef6d63970a2a3cce175bfb890f3a583438406L218-L250)`)

These changes collectively improve the flexibility, maintainability, and user experience of the `flutter_whisperkit` package.
<!-- このPRで行った変更内容を詳細に記載してください -->

## Checklist

- [ ]  xxx